### PR TITLE
add support of PHP 7.3

### DIFF
--- a/desktop/php/Monitoring.php
+++ b/desktop/php/Monitoring.php
@@ -83,7 +83,7 @@ $eqLogics = eqLogic::byType($plugin->getId());
 								<select id="sel_object" class="eqLogicAttr form-control" data-l1key="object_id">
 									<option value="">{{Aucun}}</option>
 									<?php
-										foreach (object::all() as $object) {
+										foreach (jeeObject::all() as $object) {
 										echo '<option value="' . $object->getId() . '">' . $object->getName() . '</option>';
 										}
 									?>

--- a/plugin_info/info.json
+++ b/plugin_info/info.json
@@ -4,7 +4,7 @@
 	"description" : "Plugin permettant le monitoring des équipements",
 	"licence" : "AGPL",
 	"author" : "Phifi",
-	"require" : "1.10",
+	"require" : "3.0",
 	"hasDependency" : true,
 	"category" : "monitoring",
 	"language" : ["fr_FR","en_US","de_DE","es_ES"],


### PR DESCRIPTION
update min version to 3.0 
Needed to use jeeObject instead of Object class to ensure compatibility with PHP 7.3 and Debian Buster