### PR TITLE
Compatibilité des infos HDD avec les RPi Zero

### DIFF
--- a/core/class/Monitoring.class.php
+++ b/core/class/Monitoring.class.php
@@ -658,7 +658,7 @@ public static $_widgetPossibility = array('custom' => true, 'custom::layout' => 
 
 						$hddcmd = "df -h | grep '/$' | head -1 | awk '{ print $2,$3,$5 }'";
 						$hdddata = ssh2_exec($connection, $hddcmd);
-						$hdddata = str_replace(array("K ","M ","G "),array("Ko ","Mo ","Go "), $hdddata);
+						/* $hdddata = str_replace(array("K ","M ","G "),array("Ko ","Mo ","Go "), $hdddata); */
 						stream_set_blocking($hdddata, true);
 						$hdd = stream_get_contents($hdddata);
 


### PR DESCRIPTION
Mis en commentaire d'un ligne empêchant l'affichage de l'espace disque des Raspberry Pi Zero
Ligne 661
Testé ok sur 2 clients Jeedom.