### PR TITLE
Utilisation d'un find pour récupérer la temp. CPU sur synology

### DIFF
--- a/core/class/Monitoring.class.php
+++ b/core/class/Monitoring.class.php
@@ -645,7 +645,7 @@ class Monitoring extends eqLogic {
 						stream_set_blocking($versionsynooutput, true);
 						$versionsyno = stream_get_contents($versionsynooutput);
 
-						$cputemp0cmd = "cat /sys/bus/platform/devices/coretemp.0/hwmon/hwmon0/device/temp2_input";
+						$cputemp0cmd = "cat $(find /sys/devices/platform/coretemp.0/* -name temp*_input | head -1)";
 						$cputemp0output = ssh2_exec($connection, $cputemp0cmd);
 						stream_set_blocking($cputemp0output, true);
 						$cputemp0 = stream_get_contents($cputemp0output);


### PR DESCRIPTION
Bonjour, 

Le chemin vers les fichiers permettant de récupérer la température CPU sur synology n'est pas constant entre les différentes version de DSM, peut être même en fonction du hardware... ([lien forum discussion](https://community.jeedom.com/t/monitoring-temperature-cpu-sur-nas-synology/30065))

=> Pour retrouver un fichier tempX_input, je propose la mise en place d'un find pour aller chercher dans un arborescence un peu plus large. 

J'ai PR sur la master, mais je peux switcher au besoin.