### PR TITLE
ajout configuration chemin température

### DIFF
--- a/core/class/Monitoring.class.php
+++ b/core/class/Monitoring.class.php
@@ -645,7 +645,13 @@ class Monitoring extends eqLogic {
 						stream_set_blocking($versionsynooutput, true);
 						$versionsyno = stream_get_contents($versionsynooutput);
 
-						$cputemp0cmd = "cat $(find /sys/devices/platform/coretemp.0/* -name temp*_input | head -1)";
+						$synocmdTemp='$(find /sys/devices/* -name temp*_input | head -1)';
+						if($this->getconfiguration('syno_use_temp_path'))$synocmdTemp=$this->getconfiguration('syno_temp_path');
+						
+
+						$cputemp0cmd = "timeout 3 cat ".$synocmdTemp;
+						log::add(__CLASS__,"debug", "commande temp syno : ".$cputemp0cmd);
+						
 						$cputemp0output = ssh2_exec($connection, $cputemp0cmd);
 						stream_set_blocking($cputemp0output, true);
 						$cputemp0 = stream_get_contents($cputemp0output);

--- a/desktop/js/Monitoring.js
+++ b/desktop/js/Monitoring.js
@@ -69,3 +69,20 @@ function addCmdToTable(_cmd) {
 	$('#table_cmd tbody tr:last').setValues(_cmd, '.cmdAttr');
 	jeedom.cmd.changeType($('#table_cmd tbody tr:last'), init(_cmd.subType));
 }
+
+
+
+$(".eqLogicAttr[data-l2key='synology']").on('change', function () {
+	if(this.checked){
+	  $(".syno_conf").show();
+	}else{
+	  $(".syno_conf").hide();
+	}
+  });
+  $(".eqLogicAttr[data-l2key='syno_use_temp_path']").on('change', function () {
+	if(this.checked){
+	  $(".syno_conf_temppath").show();
+	}else{
+	  $(".syno_conf_temppath").hide();
+	}
+  });

--- a/desktop/php/Monitoring.php
+++ b/desktop/php/Monitoring.php
@@ -166,6 +166,7 @@ $eqLogics = eqLogic::byType($plugin->getId());
                                         <span style="font-size: 75%;">({{à cocher seulement si vous désirez Monitorer un NAS Synology}})</span>
                                     </div>
                                 </div>
+                                <div class="syno_conf">
                                 <div class="form-group">
                                     <label class="col-md-2 control-label" >{{Volume 2}}</label>
                                     <div class="col-md-8">
@@ -173,7 +174,7 @@ $eqLogics = eqLogic::byType($plugin->getId());
                                         <span style="font-size: 75%;">({{à cocher seulement si vous avez un 2ème volume (Volume 2) dans Synology. Le volume 1 est pris en compte par défaut}})</span>
                                     </div>
                                 </div>
-                                <div class="syno_conf">
+                                
                                     <div class="form-group">
                                         <label class="col-md-2 control-label" >{{Chemin temp utilisateur}}</label>
                                         <div class="col-md-8">

--- a/desktop/php/Monitoring.php
+++ b/desktop/php/Monitoring.php
@@ -173,6 +173,22 @@ $eqLogics = eqLogic::byType($plugin->getId());
                                         <span style="font-size: 75%;">({{à cocher seulement si vous avez un 2ème volume (Volume 2) dans Synology. Le volume 1 est pris en compte par défaut}})</span>
                                     </div>
                                 </div>
+                                <div class="syno_conf">
+                                    <div class="form-group">
+                                        <label class="col-md-2 control-label" >{{Chemin temp utilisateur}}</label>
+                                        <div class="col-md-8">
+                                            <input type="checkbox" class="eqLogicAttr" data-l1key="configuration"  data-l2key="syno_use_temp_path" >
+                                            <span style="font-size: 75%;">({{si vous souhaitez spécifier directement le chemin pour récupérer la température}})</span>
+                                        </div>
+                                    </div>
+
+                                    <div class="form-group syno_conf_temppath">
+                                        <label class="col-md-2 control-label" >{{chemin temp}}</label>
+                                        <div class="col-md-8">
+                                            <input class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="syno_temp_path" type="text" placeholder="{{/sys/devices/platform/coretemp.0/temp2_input}}">
+                                        </div>
+                                    </div>
+                                </div>
 					       </fieldset>
                         </form>
                     </div>


### PR DESCRIPTION
Bonjour,
toujours pour ces histoires de température sur synology 

* Ajout d'un timeout sur la commande find pour ne pas bloquer l'execution si le find échoue..
* ajout d'une configuration pour spécifier un chemin en dur vers le chemin de température (si non coché, on utlise la commande find)
* avec un peu de js pour masquer les options si pas de syno.

[même sujet qui continue](https://community.jeedom.com/t/monitoring-temperature-cpu-sur-nas-synology/30065/70)