### PR TITLE
Update Monitoring.class.php (nb CPU Odroid C2)

### DIFF
--- a/core/class/Monitoring.class.php
+++ b/core/class/Monitoring.class.php
@@ -697,7 +697,7 @@ class Monitoring extends eqLogic {
 						}
 
 					}elseif ($ARMv == 'armv7l' || $ARMv == 'aarch64' || $ARMv == 'mips64'){
-						$nbcpuARMcmd = "lscpu | grep 'CPU(s):' | awk '{ print $2 }'";
+						$nbcpuARMcmd = "lscpu | grep '^CPU(s):' | awk '{ print $2 }'";
 						$nbcpuoutput = ssh2_exec($connection, $nbcpuARMcmd);
 						stream_set_blocking($nbcpuoutput, true);
 						$nbcpu = stream_get_contents($nbcpuoutput);
@@ -1012,7 +1012,7 @@ class Monitoring extends eqLogic {
 				}
 			}elseif ($ARMv == 'armv7l' || $ARMv == 'aarch64'){
 				$uname = '.';
-				$nbcpuARMcmd = "lscpu | grep 'CPU(s):' | awk '{ print $2 }'";
+				$nbcpuARMcmd = "lscpu | grep '^CPU(s):' | awk '{ print $2 }'";
 				$nbcpu = exec($nbcpuARMcmd);
 				$cpufreq0ARMcmd = "cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq";
 				$cpufreq0 = exec($cpufreq0ARMcmd);


### PR DESCRIPTION
Je propose cette modification pour détecter la bonne valeur du nombre de CPU sur un Jeedom tournant sous Odroid C2 (sous Armbian). 

En effet, la commande : lscpu | grep 'CPU(s):' | awk '{ print $2 }' sort deux résultats sous armbian : "4" et "node0", car lscpu | grep 'CPU(s):' sort comme résultat : "CPU(s):              4" mais aussi "NUMA node0 CPU(s):   0-3".

Je propose donc d'ajouter un '^CPU' (pour le cpu de type 'aarch64') au lieu de 'CPU' tout court pour ne sortir que la ligne débutant avec le mot CPU(s), ce qui permet d'avoir la bonne valeur (4 ici).